### PR TITLE
Add Year-Based Top Tracks Feature Using Last.fm API

### DIFF
--- a/backend/routes/music.js
+++ b/backend/routes/music.js
@@ -8,31 +8,28 @@ const LASTFM_API_KEY = process.env.LASTFM_API_KEY;
 
 router.get('/:date', async (req, res) => {
   const { date } = req.params;
+  const year = date.split('-')[0];
 
   try {
-    // 연도만 추출 (YYYY-MM-DD → YYYY)
-    const year = date.split('-')[0];
-
-    // Last.fm은 날짜별 API가 없으므로 chart 기준으로 인기곡 받아오기
+    // 연도 기반 tag 사용 (예: 1995년 → tag=1995)
     const response = await axios.get('http://ws.audioscrobbler.com/2.0/', {
       params: {
-        method: 'chart.gettoptracks',
+        method: 'tag.gettoptracks',
+        tag: year, // 여기서 연도 기반
         api_key: LASTFM_API_KEY,
         format: 'json'
       }
     });
 
-    // 상위 5~10곡만 잘라서 구성
-    const topTracks = response.data.tracks.track.slice(0, 10).map(track => ({
+    const topTracks = response.data.tracks.track.slice(0, 3).map(track => ({
       title: track.name,
       artist: track.artist.name,
-      image: track.image?.[2]?.['#text'] || null  // medium 사이즈 앨범 커버
     }));
 
     res.json({ date, topTracks });
 
   } catch (error) {
-    console.error(error);
+    console.error('🎵 Music API Error:', error.message);
     res.status(500).json({ error: 'Failed to fetch music data' });
   }
 });


### PR DESCRIPTION
- Switched from general chart-based top tracks to year-based filtering
- Extracted year from the selected date to fetch relevant music data
- Displaying top 3 tracks as text (album covers removed due to API limitation)
- Placeholder UI styled to visually emphasize music content
