### PR TITLE
Add BLS API integration for consumer prices with fallback mechanism

### DIFF
--- a/backend/config/bls.js
+++ b/backend/config/bls.js
@@ -1,0 +1,44 @@
+const axios = require('axios');
+
+const BLS_API_KEY = process.env.BLS_API_KEY;
+
+// BLS API 기본 함수
+const getBLSData = async (seriesIds, startYear, endYear) => {
+  const response = await axios.post('https://api.bls.gov/publicAPI/v2/timeseries/data/', {
+    registrationKey: BLS_API_KEY,
+    seriesid: seriesIds,
+    startyear: startYear,
+    endyear: endYear
+  });
+
+  return response.data;
+};
+
+// ✅ 우리가 price.js에서 쓸 함수
+const getBLSPrices = async (dateString) => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+
+  const seriesIds = {
+    milk: 'APU0000709112',   // 우유 1갤런
+    bread: 'APU0000702111',  // 식빵 1파운드
+    egg: 'APU0000708111',    // 계란 1 dozen
+    beef: 'APU0000703111'    // 소고기 1파운드
+  };
+
+  const result = await getBLSData(Object.values(seriesIds), year, year);
+  const prices = {};
+
+  result.Results.series.forEach((series) => {
+    const itemKey = Object.keys(seriesIds).find(key => series.seriesID === seriesIds[key]);
+    const monthlyData = series.data.find(item => item.period === `M${month}`);
+    if (itemKey && monthlyData) {
+      prices[itemKey] = parseFloat(monthlyData.value);
+    }
+  });
+
+  return prices;
+};
+
+module.exports = { getBLSData, getBLSPrices };

--- a/backend/routes/news.js
+++ b/backend/routes/news.js
@@ -22,8 +22,8 @@ router.get('/:date', async (req, res) => {
 
     const articles = response.data.response.results.slice(0, 6).map(article => {
       const fullText = article.fields?.bodyText || '';
-      const summary = fullText.length > 300
-        ? fullText.slice(0, 300) + '...'
+      const summary = fullText.length > 500
+        ? fullText.slice(0, 500) + '...'
         : fullText;
 
       return {

--- a/backend/routes/price.js
+++ b/backend/routes/price.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const axios = require('axios');
+const { getBLSPrices } = require('../config/bls'); // ✅ BLS 함수 불러오기
 
+// 환율 데이터 가져오기
 const getExchangeRates = async (date) => {
   const res = await axios.get(`https://api.frankfurter.app/${date}`, {
     params: {
@@ -18,17 +20,24 @@ const getExchangeRates = async (date) => {
   };
 };
 
-
-// 🥛 소비자물가 데이터 (단위: USD 또는 USD/pound 등)
+// 소비자물가 데이터 (BLS 기반으로 시도하고, 실패하면 fallback 고정값 사용)
 const getConsumerPrices = async (date) => {
-  return {
-    milk: 2.83,       // 우유 1갤런
-    bread: 0.319,     // 식빵 1파운드
-    egg: 2.812,       // 계란 1 dozen
-    beef: 2.152       // 소고기 1파운드
-  };
+  try {
+    const prices = await getBLSPrices(date); // ✅ 실제 BLS 요청
+    return prices;
+  } catch (err) {
+    console.error('🔻 Failed to fetch BLS data, using fallback values');
+    // 제한 초과 등 에러 시, 예시값 반환
+    return {
+      milk: 2.83,       // 우유 1갤런
+      bread: 0.319,     // 식빵 1파운드
+      egg: 2.812,       // 계란 1 dozen
+      beef: 2.152       // 소고기 1파운드
+    };
+  }
 };
 
+// 라우터
 router.get('/:date', async (req, res) => {
   const { date } = req.params;
   try {


### PR DESCRIPTION
### Summary
- Integrated the BLS API to fetch historical consumer prices (milk, bread, egg, beef)
- Implemented a fallback to static values when the API fails (e.g. request limit exceeded)
- Ensured the exchange rates still display even if consumer prices fail
- Increased the character limit for news article summaries to 500 characters

Tested with various historical dates and confirmed fallback behavior works.
